### PR TITLE
Fix hardcoded local path in CLaRaConfig default for compr_base_model_name

### DIFF
--- a/openrlhf/models/modeling_clara.py
+++ b/openrlhf/models/modeling_clara.py
@@ -138,7 +138,7 @@ class CLaRaConfig(PretrainedConfig):
                  compr_rate: int = 64,
                  compr_n_layers: int = None,
                  compr_every_n_layer: int = None,
-                 compr_base_model_name: str = '/mnt/ceph_rbd/model/Mistral-7B-Instruct-v0.2',
+                 compr_base_model_name: str = 'mistralai/Mistral-7B-Instruct-v0.2',
                  compr_rms_norm: bool = False,
                  compr_mlp_hidden_dim: int = 8096,
                  compr_use_mlp: bool = True,


### PR DESCRIPTION
## Description

Replace the internal development path `/mnt/ceph_rbd/model/Mistral-7B-Instruct-v0.2` with the HuggingFace model ID `mistralai/Mistral-7B-Instruct-v0.2` for the `compr_base_model_name` parameter default value in `CLaRaConfig`.

## Problem

The current default value is a hardcoded local filesystem path that won't exist on users' systems, causing confusing errors when instantiating `CLaRaConfig` without explicitly setting this parameter.

## Solution

Use the official HuggingFace model ID instead, which can be automatically downloaded by users.

## Changes

- `openrlhf/models/modeling_clara.py`: Line 141 - Changed default value from local path to HuggingFace model ID